### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # CMakeList.txt : CMake project for FastNoise
-cmake_minimum_required (VERSION 3.7.1)
+cmake_minimum_required (VERSION 3.12)
 
 project(FastNoiseTool)
 set(CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
Hello, great work! Have been using your older libs for quite long time. It's good to see that they will get a successor :)
On pull request:  CMP0074 was [introduced](https://cmake.org/cmake/help/v3.12/policy/CMP0074.html) in CMAKE 3.12, so I fixed that. 